### PR TITLE
Edit phone number in footer from 919.506.0171 to 919.560.0171

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Local Development
 
-1. You'll need node v13.5.0. Use NVM to use this version.
+1. You'll need node v13.7.0. Use NVM to use this version.
 1. Install theme dependencies: `yarn`
 1. Run `yarn add airtable-json --dev --ignore-engines`
 1. Run `yarn add image-downloader --dev --ignore-engines`

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -57,7 +57,7 @@ export const timelineDescription = `The Durham Civil Rights Heritage Project (DC
 export const libraryInfo = [
   '300 N. Roxboro Street',
   'Durham, North Carolina 27701',
-  '919.506.0171',
+  '919.560.0171',
   { url: 'mailto:ncc@dconc.gov', text: 'Email the North Carolina Collection' },
 ];
 


### PR DESCRIPTION
## Request
Slack thread for reference: [https://savaslabs.slack.com/archives/CLSP1AX47/p1744803435464919](https://savaslabs.slack.com/archives/CLSP1AX47/p1744803435464919)

The request was to change the phone number in the footer to 919-560-0171 (from 919-560-0171). 

## Notes
It says to use node v.13.5.0 to spin up locally, but I ran into errors when running yarn on 13.5:
```
error browserslist@4.13.0: The engine "node" is incompatible with this module. Expected version "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7". Got "13.5.0"
error Found incompatible module.
```
I switched to v.13.7 and was able to spin up the site with no issues. I did get updates to my package.json and yarn.lock files after running `yarn add airtable-json --dev --ignore-engines` and `yarn add image-downloader --dev --ignore-engines` but did not commit those.

I checked our Netlify account, and I see Node 13.7.0 in the [Environmental Variables](https://app.netlify.com/sites/dlib/configuration/env#environment-variables)
Deploy context | Value |  
-- | -- | --
Production | 13.7.0 |  
Deploy Previews | 13.7.0 |  
Branch deploys | 13.7.0 |  
Preview Server | 13.7.0 |  
Local development (Netlify CLI) | 13.7.0

Due to this, I decided to also commit an edit to the README to use Node 13.7.0 for local setup vs. 13.5.0.

## Testing
Assuming anyone reviewing is spinning this up for the first time, to review:

- [x] Checkout this branch
- [x] `nvm install 13.7.0`
- [x] `nvm use 13.7.0`
- [x] Install theme dependencies: `yarn`
- [x] Run `yarn add airtable-json --dev --ignore-engines`
- [x] Run `yarn add image-downloader --dev --ignore-engines`
- [x] Development: `yarn start`
- [x] Go to [http://localhost:8080/](http://localhost:8080/) if it does not open automatically
- [x] Scroll to the bottom of the page or [a shorter page](http://localhost:8080/events/royal_ice_cream_sit_in_1957) and confirm the phone number in the footer is 919-560-0171.
