### PR TITLE
Fix hover state mismatch in navigation dropdown menu, moving from li to a elements

### DIFF
--- a/app/components/SubMenu.js
+++ b/app/components/SubMenu.js
@@ -63,23 +63,26 @@ const SubmenuItem = styled.li`
   padding: 20px 0;
   margin: 0 18px;
   border-bottom: 0.5px solid ${props => props.theme.colors.white};
+  cursor: default;
 
   @media ${props => props.theme.breakpoints.md} {
     border-bottom-color: ${props => props.theme.colors.greenBean};
   }
 
   a {
+    cursor: pointer;
+    
     @media ${props => props.theme.breakpoints.smMax} {
       color: ${props => props.theme.colors.white} !important;
     }
-  }
+    
+    &:hover,
+    &:focus {
+      font-weight: ${props => props.theme.fontWeight.bold};
 
-  &:hover a,
-  &:focus a {
-    font-weight: ${props => props.theme.fontWeight.bold};
-
-    @media ${props => props.theme.breakpoints.md} {
-      font-weight: ${props => props.theme.fontWeight.semiBold};
+      @media ${props => props.theme.breakpoints.md} {
+        font-weight: ${props => props.theme.fontWeight.semiBold};
+      }
     }
   }
 

--- a/app/components/SubMenu.js
+++ b/app/components/SubMenu.js
@@ -60,17 +60,16 @@ const SubMenu = styled.ul`
 const SubmenuItem = styled.li`
   font-size: ${props => props.theme.fontSize.xs};
   font-weight: ${props => props.theme.fontWeight.regular};
-  padding: 20px 0;
   margin: 0 18px;
   border-bottom: 0.5px solid ${props => props.theme.colors.white};
-  cursor: default;
 
   @media ${props => props.theme.breakpoints.md} {
     border-bottom-color: ${props => props.theme.colors.greenBean};
   }
 
   a {
-    cursor: pointer;
+    display: block;
+    padding: 20px 0;
     
     @media ${props => props.theme.breakpoints.smMax} {
       color: ${props => props.theme.colors.white} !important;


### PR DESCRIPTION
## Request
Slack thread for reference: [https://savaslabs.slack.com/archives/C014PHVKEF9/p1744903955777089?thread_ts=1744903164.776809&cid=C014PHVKEF9](https://savaslabs.slack.com/archives/C014PHVKEF9/p1744903955777089?thread_ts=1744903164.776809&cid=C014PHVKEF9)

The request was to adjust the hover state area to match the actual clickable link area on dropdown menu items under Featured Events.

## Testing

- [x] Checkout this branch
- [x] `nvm use 13.7.0`
- [ ] If this is the first time spinning it up:
  - [ ] Install theme dependencies: `yarn`
  - [ ] Run `yarn add airtable-json --dev --ignore-engines`
  - [ ] Run `yarn add image-downloader --dev --ignore-engines`
- [x] Run`yarn start`
- [x] Go to [http://localhost:8080/](http://localhost:8080/) if it does not open automatically
- [x] Click on Featured Events in the navigation. Confirm the hover state including the cursor pointer is only showing when you are hovering on the link itself, not the full `li` element. You can compare with the [current state here](https://www.durhamcountylibrary.org/exhibits/dcrhp/) for reference.
